### PR TITLE
set allow_binary to true

### DIFF
--- a/.tekton/odh-feature-server-v2-20-push.yaml
+++ b/.tekton/odh-feature-server-v2-20-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: path-context
     value: "."
   - name: prefetch-input
-    value: [{"type": "pip", "path": "sdk/python/requirements", "requirements_files": ["py3.11-requirements.txt"], "allow_binary": "false"}]
+    value: [{"type": "pip", "path": "sdk/python/requirements", "requirements_files": ["py3.11-requirements.txt"], "allow_binary": "true"}]
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
enabling allow_binary to have a green build to create a 2.20 nightly.

slack thread: https://redhat-internal.slack.com/archives/C05NXTEHLGY/p1738160905178299