### PR TITLE
add LABELs when building container images for Konflux

### DIFF
--- a/Dockerfiles/Dockerfile.feast-operator.konflux
+++ b/Dockerfiles/Dockerfile.feast-operator.konflux
@@ -22,11 +22,17 @@ COPY internal/controller/ internal/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.10@sha256:9b1da1a65e3c8c95da436402a9ecf5e1e8df9cbee33bd5e1e43c02faf914daae as runtime
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.10@sha256:9b1da1a65e3c8c95da436402a9ecf5e1e8df9cbee33bd5e1e43c02faf914daae
 WORKDIR /
 COPY --from=builder /opt/app-root/src/manager .
-
-FROM runtime
-
 USER 65532:65532
+
 ENTRYPOINT ["/manager"]
+
+LABEL com.redhat.component="odh-feast-operator" \
+      name="odh-feast-operator-rhel8" \
+      description="odh-feast-operator" \
+      summary="odh-feast-operator" \
+      io.openshift.expose-services="65532" \
+      io.k8s.display-name="odh-feast-operator" \
+      io.k8s.description="odh-feast-operator"

--- a/Dockerfiles/Dockerfile.feast-operator.konflux
+++ b/Dockerfiles/Dockerfile.feast-operator.konflux
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22.9@sha256:c7ebff72ffae334ad1b90b59189ac1ee21ad175f2014ddcb8563511350a0b23f
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22.9@sha256:c7ebff72ffae334ad1b90b59189ac1ee21ad175f2014ddcb8563511350a0b23f AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfiles/Dockerfile.feast-operator.konflux
+++ b/Dockerfiles/Dockerfile.feast-operator.konflux
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22.9@sha256:c7ebff72ffae334ad1b90b59189ac1ee21ad175f2014ddcb8563511350a0b23f AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22.9@sha256:c7ebff72ffae334ad1b90b59189ac1ee21ad175f2014ddcb8563511350a0b23f
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfiles/Dockerfile.feast-operator.konflux
+++ b/Dockerfiles/Dockerfile.feast-operator.konflux
@@ -22,9 +22,11 @@ COPY internal/controller/ internal/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.10@sha256:9b1da1a65e3c8c95da436402a9ecf5e1e8df9cbee33bd5e1e43c02faf914daae
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.10@sha256:9b1da1a65e3c8c95da436402a9ecf5e1e8df9cbee33bd5e1e43c02faf914daae as runtime
 WORKDIR /
 COPY --from=builder /opt/app-root/src/manager .
-USER 65532:65532
 
+FROM runtime
+
+USER 65532:65532
 ENTRYPOINT ["/manager"]

--- a/Dockerfiles/Dockerfile.feature-server.konflux
+++ b/Dockerfiles/Dockerfile.feature-server.konflux
@@ -6,4 +6,10 @@ RUN pip install -r requirements.txt
 # modify permissions to support running with a random uid
 RUN chmod g+w $(python -c "import feast.ui as ui; print(ui.__path__)" | tr -d "[']")/build/projects-list.json
 
-FROM builder
+LABEL com.redhat.component="odh-feature-server" \
+      name="odh-feature-server-rhel8" \
+      description="odh-feature-server" \
+      summary="odh-feature-server" \
+      io.openshift.expose-services="" \
+      io.k8s.display-name="odh-feature-server" \
+      io.k8s.description="odh-feature-server"

--- a/Dockerfiles/Dockerfile.feature-server.konflux
+++ b/Dockerfiles/Dockerfile.feature-server.konflux
@@ -1,7 +1,9 @@
-FROM registry.access.redhat.com/ubi8/python-311:1@sha256:6f6592717b9d88dc1ace1c4c144cfcbf59afa288edeb3cdd7a79d6d2f7467a11
+FROM registry.access.redhat.com/ubi8/python-311:1@sha256:6f6592717b9d88dc1ace1c4c144cfcbf59afa288edeb3cdd7a79d6d2f7467a11 as builder
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
 # modify permissions to support running with a random uid
 RUN chmod g+w $(python -c "import feast.ui as ui; print(ui.__path__)" | tr -d "[']")/build/projects-list.json
+
+FROM builder

--- a/Dockerfiles/Dockerfile.feature-server.konflux
+++ b/Dockerfiles/Dockerfile.feature-server.konflux
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-311:1@sha256:6f6592717b9d88dc1ace1c4c144cfcbf59afa288edeb3cdd7a79d6d2f7467a11 as builder
+FROM registry.access.redhat.com/ubi8/python-311:1@sha256:6f6592717b9d88dc1ace1c4c144cfcbf59afa288edeb3cdd7a79d6d2f7467a11
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Konflux's Enterprice Contract/ Conforma check is highlighting a violation of:
The "xxx" label should not be inherited from
the parent image

Set the LABELs for both feature-server and feast-operator container images to resolve the violation.

Related to: RHOAIENG-23591
