### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-feast-operator-v2-22

### DIFF
--- a/Dockerfiles/Dockerfile.feast-operator.konflux
+++ b/Dockerfiles/Dockerfile.feast-operator.konflux
@@ -30,7 +30,8 @@ USER 65532:65532
 ENTRYPOINT ["/manager"]
 
 LABEL com.redhat.component="odh-feast-operator" \
-      name="odh-feast-operator-rhel9" \
+      name="rhoai/odh-feast-operator-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       description="odh-feast-operator" \
       summary="odh-feast-operator" \
       io.k8s.display-name="odh-feast-operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
