### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-feature-server-v2-21

### DIFF
--- a/Dockerfiles/Dockerfile.feature-server.konflux
+++ b/Dockerfiles/Dockerfile.feature-server.konflux
@@ -7,7 +7,8 @@ RUN pip install -r requirements.txt
 RUN chmod g+w $(python -c "import feast.ui as ui; print(ui.__path__)" | tr -d "[']")/build/projects-list.json
 
 LABEL com.redhat.component="odh-feature-server" \
-      name="odh-feature-server-rhel9" \
+      name="rhoai/odh-feature-server-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.21::el9" \
       description="odh-feature-server" \
       summary="odh-feature-server" \
       io.openshift.expose-services="" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
