### PR TITLE
fix: upgrade Meson to fix pandas 2.3.3 build on ppc64le

### DIFF
--- a/.tekton/odh-feature-server-pull-request.yaml
+++ b/.tekton/odh-feature-server-pull-request.yaml
@@ -79,6 +79,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: rhoai-version
+    value: "2.25.0"
   pipelineRef:
     resolver: git
     params:

--- a/sdk/python/feast/infra/feature_servers/multicloud/prebuild-power.sh
+++ b/sdk/python/feast/infra/feature_servers/multicloud/prebuild-power.sh
@@ -23,7 +23,7 @@ export CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++
 : "${LINKFLAGS:=""}"
 
 # Installing Python build dependencies
-python${PYTHON_VERSION} -m pip install build wheel setuptools ninja pybind11 numpy setuptools_scm Cython==3.0.8
+python${PYTHON_VERSION} -m pip install 'meson>=1.2.0,<1.11' meson-python build wheel setuptools ninja pybind11 numpy setuptools_scm Cython==3.0.8
 
 # Directory to collect built wheels
 mkdir -p /wheelhouse
@@ -101,7 +101,7 @@ export CC=gcc
 export CXX=g++
 export CXXFLAGS="-std=c++17"
 
-python${PYTHON_VERSION} -m pip install conan==1.64.1 setuptools==70.0.0
+python${PYTHON_VERSION} -m pip install conan==1.64.1 setuptools
 
 git clone https://github.com/milvus-io/milvus-lite
 cd milvus-lite/python

--- a/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
+++ b/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
@@ -1,2 +1,3 @@
 # keep VERSION on line #2, this is critical to release CI
 feast[minimal] == 0.54.0
+pydantic==2.10.6  # Explicit pin for cachi2 prefetch


### PR DESCRIPTION
  pandas 2.3.3 requires Meson >=1.2.0 to build from source on ppc64le.
  The build was failing with Meson 1.11.0 due to type checking issues
  in extension module dependencies. This adds meson-python build backend
  and ensures compatible Meson version.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing and why.
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [ ] I've made sure the tests are passing.
- [ ] My commits are signed off (`git commit -s`)
- [ ] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
