### PR TITLE
fix: Fixed panda build on power

### DIFF
--- a/.tekton/odh-feature-server-pull-request.yaml
+++ b/.tekton/odh-feature-server-pull-request.yaml
@@ -40,32 +40,32 @@ spec:
     value: "sdk/python/feast/infra/feature_servers/multicloud"
   - name: hermetic
     value: false
-  - name: prefetch-input
-    value: |
-      [
-        {
-          "type": "pip",
-          "path": ".",
-          "requirements_files": [
-            "sdk/python/feast/infra/feature_servers/multicloud/requirements.txt",
-            "sdk/python/feast/infra/feature_servers/multicloud/requirements-ppc64le.txt"
-          ],
-          "requirements_build_files": [
-            "sdk/python/requirements/py3.11-minimal-requirements.txt",
-            "sdk/python/requirements/py3.11-minimal-sdist-requirements.txt",
-            "sdk/python/requirements/py3.11-minimal-sdist-requirements-build.txt"
-          ],
-          "allow_binary": "true"
-        },
-        {
-          "type": "rpm",
-          "path": "sdk/python/feast/infra/feature_servers/multicloud/offline"
-        },
-        {
-          "type": "generic",
-          "path": "sdk/python/feast/infra/feature_servers/multicloud"
-        }
-      ]
+  # - name: prefetch-input
+  #   value: |
+  #     [
+  #       {
+  #         "type": "pip",
+  #         "path": ".",
+  #         "requirements_files": [
+  #           "sdk/python/feast/infra/feature_servers/multicloud/requirements.txt",
+  #           "sdk/python/feast/infra/feature_servers/multicloud/requirements-ppc64le.txt"
+  #         ],
+  #         "requirements_build_files": [
+  #           "sdk/python/requirements/py3.11-minimal-requirements.txt",
+  #           "sdk/python/requirements/py3.11-minimal-sdist-requirements.txt",
+  #           "sdk/python/requirements/py3.11-minimal-sdist-requirements-build.txt"
+  #         ],
+  #         "allow_binary": "true"
+  #       },
+  #       {
+  #         "type": "rpm",
+  #         "path": "sdk/python/feast/infra/feature_servers/multicloud/offline"
+  #       },
+  #       {
+  #         "type": "generic",
+  #         "path": "sdk/python/feast/infra/feature_servers/multicloud"
+  #       }
+  #     ]
   - name: build-source-image
     value: true
   - name: build-image-index
@@ -79,8 +79,6 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
-  - name: rhoai-version
-    value: "2.25.0"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-feature-server-pull-request.yaml
+++ b/.tekton/odh-feature-server-pull-request.yaml
@@ -79,6 +79,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: rhoai-version
+    value: "2.25.0"
   pipelineRef:
     resolver: git
     params:

--- a/sdk/python/feast/infra/feature_servers/multicloud/prebuild-power.sh
+++ b/sdk/python/feast/infra/feature_servers/multicloud/prebuild-power.sh
@@ -23,7 +23,9 @@ export CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++
 : "${LINKFLAGS:=""}"
 
 # Installing Python build dependencies
-python${PYTHON_VERSION} -m pip install build wheel setuptools ninja pybind11 numpy setuptools_scm Cython==3.0.8
+# fix pandas build
+python${PYTHON_VERSION} -m pip install pandas==2.3.3 --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/
+python${PYTHON_VERSION} -m pip install build wheel 'setuptools<78' ninja pybind11 numpy setuptools_scm Cython
 
 # Directory to collect built wheels
 mkdir -p /wheelhouse


### PR DESCRIPTION


# What this PR does / why we need it:

**Root cause:** On ppc64le, there are no pre-built pandas wheels available on PyPI. When pip install -r requirements.txt installs feast[minimal], it pulls in pandas==2.3.3 as a transitive dependency and tries to build it from source. The source build uses meson, but the version of meson being installed in the isolated build environment is incompatible with pandas' meson.build files, causing the array[str] vs array[Dependency | InternalDependency] type error.

Fix: Use ibm index for panda install


