### PR TITLE
Cherrypick PR to main  (#224)

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/prebuild-power.sh
+++ b/sdk/python/feast/infra/feature_servers/multicloud/prebuild-power.sh
@@ -25,7 +25,9 @@ export LDFLAGS="-Wl,--stub-group-size=0x00002000 -Wl,--gc-sections"
 : "${LINKFLAGS:=""}"
 
 # Installing Python build dependencies
-python${PYTHON_VERSION} -m pip install build wheel 'setuptools<78' ninja pybind11 numpy==2.3.3 setuptools_scm Cython
+# fix pandas build
+python${PYTHON_VERSION} -m pip install pandas==2.3.3 --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/
+python${PYTHON_VERSION} -m pip install build wheel 'setuptools<78' ninja pybind11 numpy setuptools_scm Cython
 
 # Directory to collect built wheels
 mkdir -p /wheelhouse


### PR DESCRIPTION
use prebuilt pandas wheel to avoid meson build failure on power