### PR TITLE
Fix milvus-lite issue

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/prebuild-power.sh
+++ b/sdk/python/feast/infra/feature_servers/multicloud/prebuild-power.sh
@@ -102,8 +102,7 @@ dnf install -y perl ncurses-devel wget openblas-devel cargo gcc gcc-c++ libstdc+
 
 python${PYTHON_VERSION} -m pip install conan==1.64.1 setuptools==70.0.0
 
-git clone https://github.com/milvus-io/milvus-lite
+git clone -b v2.4.12 https://github.com/milvus-io/milvus-lite.git
 cd milvus-lite/python
-git checkout v2.4.12
 git submodule update --init --recursive
 python${PYTHON_VERSION} -m pip install -v -e .


### PR DESCRIPTION
Currently, the script clones the default branch (main) of milvus-lite. Recently, the `**python**` directory was removed from the main branch, causing line 106 in the  prebuild script to fail.

This PR updates the clone command to directly clone the required v2.4.12 version of milvus-lite.