### PR TITLE
fix: Replace selector label strip patch with migration Job for upgrade-safe selector uniqueness

### DIFF
--- a/infra/feast-operator/config/overlays/odh/kustomization.yaml
+++ b/infra/feast-operator/config/overlays/odh/kustomization.yaml
@@ -6,19 +6,12 @@ namespace: opendatahub
 
 resources:
   - ../../default
+  - selector_migration_job.yaml
 
 
 patches:
   # patch to remove default `system` namespace in ../../manager/manager.yaml
   - path: delete-namespace.yaml
-  # Remove app.kubernetes.io/name from the Deployment selector to avoid
-  # immutable spec.selector errors on upgrade. The label remains in the
-  # pod template so the metrics Service selector still targets only
-  # feast-operator pods.
-  - path: remove_selector_label_patch.yaml
-    target:
-      kind: Deployment
-      name: controller-manager
 
 configMapGenerator:
   - name:  feast-operator-parameters
@@ -70,3 +63,13 @@ replacements:
           name: controller-manager
         fieldPaths:
           - spec.template.spec.containers.[name=manager].env.[name=OIDC_ISSUER_URL].value
+  - source:
+      kind: ConfigMap
+      name: feast-operator-parameters
+      fieldPath: data.RELATED_IMAGE_CRON_JOB
+    targets:
+      - select:
+          kind: Job
+          name: selector-migration
+        fieldPaths:
+          - spec.template.spec.containers.[name=migrate].image

--- a/infra/feast-operator/config/overlays/odh/remove_selector_label_patch.yaml
+++ b/infra/feast-operator/config/overlays/odh/remove_selector_label_patch.yaml
@@ -1,2 +1,0 @@
-- op: remove
-  path: /spec/selector/matchLabels/app.kubernetes.io~1name

--- a/infra/feast-operator/config/overlays/odh/selector_migration_job.yaml
+++ b/infra/feast-operator/config/overlays/odh/selector_migration_job.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: selector-migration
+  namespace: system
+  labels:
+    app.kubernetes.io/name: feast-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: feast-operator
+    spec:
+      serviceAccountName: controller-manager
+      restartPolicy: Never
+      containers:
+      - name: migrate
+        image: origin-cli:latest
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          DEPLOY="feast-operator-controller-manager"
+          NS="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+
+          if ! oc get deployment "$DEPLOY" -n "$NS" > /dev/null 2>&1; then
+            echo "Deployment $DEPLOY not found, nothing to migrate."
+            exit 0
+          fi
+
+          HAS_LABEL=$(oc get deployment "$DEPLOY" -n "$NS" \
+            -o jsonpath='{.spec.selector.matchLabels.app\.kubernetes\.io/name}' 2>/dev/null)
+
+          if [ -z "$HAS_LABEL" ]; then
+            echo "Deployment $DEPLOY has old selector (missing app.kubernetes.io/name)."
+            echo "Deleting so it can be recreated with the correct selector..."
+            oc delete deployment "$DEPLOY" -n "$NS"
+            echo "Done. The operator will recreate the Deployment."
+          else
+            echo "Deployment selector is already correct, no migration needed."
+          fi

--- a/infra/feast-operator/config/overlays/rhoai/kustomization.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/kustomization.yaml
@@ -6,19 +6,12 @@ namespace: redhat-ods-applications
 
 resources:
   - ../../default
+  - selector_migration_job.yaml
 
 
 patches:
   # patch to remove default `system` namespace in ../../manager/manager.yaml
   - path: delete-namespace.yaml
-  # Remove app.kubernetes.io/name from the Deployment selector to avoid
-  # immutable spec.selector errors on upgrade. The label remains in the
-  # pod template so the metrics Service selector still targets only
-  # feast-operator pods.
-  - path: remove_selector_label_patch.yaml
-    target:
-      kind: Deployment
-      name: controller-manager
 
 configMapGenerator:
   - name:  feast-operator-parameters
@@ -70,3 +63,13 @@ replacements:
           name: controller-manager
         fieldPaths:
           - spec.template.spec.containers.[name=manager].env.[name=OIDC_ISSUER_URL].value
+  - source:
+      kind: ConfigMap
+      name: feast-operator-parameters
+      fieldPath: data.RELATED_IMAGE_CRON_JOB
+    targets:
+      - select:
+          kind: Job
+          name: selector-migration
+        fieldPaths:
+          - spec.template.spec.containers.[name=migrate].image

--- a/infra/feast-operator/config/overlays/rhoai/remove_selector_label_patch.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/remove_selector_label_patch.yaml
@@ -1,2 +1,0 @@
-- op: remove
-  path: /spec/selector/matchLabels/app.kubernetes.io~1name

--- a/infra/feast-operator/config/overlays/rhoai/selector_migration_job.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/selector_migration_job.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: selector-migration
+  namespace: system
+  labels:
+    app.kubernetes.io/name: feast-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: feast-operator
+    spec:
+      serviceAccountName: controller-manager
+      restartPolicy: Never
+      containers:
+      - name: migrate
+        image: origin-cli:latest
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          DEPLOY="feast-operator-controller-manager"
+          NS="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+
+          if ! oc get deployment "$DEPLOY" -n "$NS" > /dev/null 2>&1; then
+            echo "Deployment $DEPLOY not found, nothing to migrate."
+            exit 0
+          fi
+
+          HAS_LABEL=$(oc get deployment "$DEPLOY" -n "$NS" \
+            -o jsonpath='{.spec.selector.matchLabels.app\.kubernetes\.io/name}' 2>/dev/null)
+
+          if [ -z "$HAS_LABEL" ]; then
+            echo "Deployment $DEPLOY has old selector (missing app.kubernetes.io/name)."
+            echo "Deleting so it can be recreated with the correct selector..."
+            oc delete deployment "$DEPLOY" -n "$NS"
+            echo "Done. The operator will recreate the Deployment."
+          else
+            echo "Deployment selector is already correct, no migration needed."
+          fi


### PR DESCRIPTION

# What this PR does / why we need it:

## Summary

- Replaces the `remove_selector_label_patch.yaml` workaround (which stripped `app.kubernetes.io/name` from the Deployment selector) with a pre-upgrade migration Job that deletes the existing `feast-operator-controller-manager` Deployment if its `spec.selector` doesn't match the expected labels
- Preserves upstream's `app.kubernetes.io/name: feast-operator` label in the Deployment selector for label uniqueness, while ensuring clean upgrades from all prior RHOAI/ODH versions (3.0 through 3.5-ea.1)

## Problem

Upgrading from any prior RHOAI release to 3.5-ea.1 fails because `spec.selector.matchLabels` is an immutable field in Kubernetes:
`Deployment.apps "feast-operator-controller-manager" is invalid: spec.selector: Invalid value: ...: field is immutable`


**Root cause:** Upstream Feast 0.61.0 (commit a1a160d9b) added `app.kubernetes.io/name: feast-operator` to the Deployment's `spec.selector.matchLabels` for metrics service selector uniqueness. All prior RHOAI releases (3.0–3.4) deployed with only `{control-plane: controller-manager}` in the selector. The existing `remove_selector_label_patch.yaml` stripped this label back out via a JSON6902 overlay, which kept the selector at 1 label — but this defeats the upstream improvement and the label would keep returning on every upstream merge.

Fixes: [RHOAIENG-58369](https://issues.redhat.com/browse/RHOAIENG-58369)

## Solution

A `selector-migration` Job (in both RHOAI and ODH overlays) that:
1. Runs using the existing `ose-cli` image (`RELATED_IMAGE_CRON_JOB` from `params.env`)
2. Uses the existing `controller-manager` ServiceAccount (already has Deployment `get`/`delete` RBAC)
3. Checks the existing Deployment's `spec.selector.matchLabels` for `app.kubernetes.io/name`
4. If missing (old selector) → deletes the Deployment so the operator can recreate it with the correct 2-label selector
5. If present → no-op, exits cleanly
6. Auto-cleans up after 300 seconds via `ttlSecondsAfterFinished`

## Upgrade compatibility (verified)

| Upgrade from | Existing selector | Migration Job action | Result |
|---|---|---|---|
| Fresh install | _(none)_ | No-op | OK |
| rhoai-3.0 / 3.2 / 3.3 | `{control-plane}` | Deletes, recreated | OK |
| rhoai-3.4-ea.1 / ea.2 | `{control-plane}` | Deletes, recreated | OK |
| rhoai-3.4 GA | `{control-plane}` | Deletes, recreated | OK |
| rhoai-3.5-ea.1 (current) | `{control-plane}` | Deletes, recreated | OK |
| Future (post-fix → post-fix) | `{app..io/name, control-plane}` | No-op | OK |

## Files changed

- **Deleted:** `overlays/rhoai/remove_selector_label_patch.yaml`, `overlays/odh/remove_selector_label_patch.yaml`
- **Added:** `overlays/rhoai/selector_migration_job.yaml`, `overlays/odh/selector_migration_job.yaml`
- **Modified:** `overlays/rhoai/kustomization.yaml`, `overlays/odh/kustomization.yaml` — removed strip patch, added Job resource + image replacement

## Test plan

- [ ] Run `kubectl kustomize` on both `overlays/rhoai/` and `overlays/odh/` — verify Deployment selector has both `app.kubernetes.io/name: feast-operator` and `control-plane: controller-manager`
- [ ] Verify the migration Job appears in the kustomize output with the correct image, ServiceAccount, and namespace
- [ ] Deploy a cluster with an older release (e.g. 3.4-ea.2) and upgrade to this branch — confirm the Job deletes the old Deployment and the operator recreates it with the correct selector
- [ ] Fresh install on a clean cluster — confirm the Job is a no-op and the Deployment is created normally
- [ ] Confirm existing FeatureStore workloads (feature-server pods) continue running through the operator Deployment recreation

## Rollback note

Rolling back from this version to a prior version (which uses the 1-label selector) will hit the same immutable selector error. Manual `oc delete deployment feast-operator-controller-manager` is required before rollback.

