### PR TITLE
[rhoai-3.5-ea.2] Update ppc64le dependencies for feature-server

### DIFF
--- a/Dockerfiles/Dockerfile.feature-server.konflux
+++ b/Dockerfiles/Dockerfile.feature-server.konflux
@@ -24,7 +24,7 @@ USER 0
 # Runtime shared libraries required by compiled Python extensions:
 #   libicu  - pyarrow (Arrow C++ depends on ICU)
 #   libpq   - psycopg[c] (PostgreSQL C adapter)
-RUN microdnf install -y git libicu libpq python3.12-devel postgresql-devel gcc && microdnf clean all
+RUN microdnf install -y git libicu libpq python3.12-devel postgresql-devel gcc openblas-devel && microdnf clean all
 
 # Copy installed Python packages and entry-point scripts from builder
 COPY --from=builder /opt/app-root/lib /opt/app-root/lib

--- a/Dockerfiles/Dockerfile.feature-server.konflux
+++ b/Dockerfiles/Dockerfile.feature-server.konflux
@@ -5,12 +5,13 @@ USER 0
 
 COPY requirements.txt requirements.txt
 
-# Run prebuild script conditionally (Power only)
+# Power (ppc64le) only: Install a known stable pyarrow version
+# to avoid compatibility issues with the version from requirements.
 RUN if [ "$(uname -m)" = "ppc64le" ]; then \
-        echo "Power architecture detected. installing required packages..."; \
-        pip install pyarrow==22.0.0 duckdb==1.4.3; \
+        echo "Power architecture detected. Installing pinned pyarrow version..."; \
+        pip install pyarrow==22.0.0; \
     else \
-        echo "Non-Power architecture detected; skipping Power prebuild"; \
+        echo "Non-Power architecture detected; skipping Power-specific pyarrow installation."; \
     fi
 
 RUN pip install -r requirements.txt

--- a/sdk/python/feast/infra/feature_servers/multicloud/requirements-ppc64le.txt
+++ b/sdk/python/feast/infra/feature_servers/multicloud/requirements-ppc64le.txt
@@ -3,14 +3,8 @@
 pyarrow==22.0.0+ppc64le1 \
     --hash=sha256:c88347a7a3ff447a893a9354d94cf4e8cd8af85ef635048f7938056d9baa8475
 
-duckdb==1.4.3+ppc64le1 \
-    --hash=sha256:613f6836ae5d6cfcf4e293a12701ca383c5201c6147cf39f1e8d925f61de0be9
-
 milvus-lite==2.4.12+ppc64le1 \
     --hash=sha256:8b5dbc216ec003c71aeb85f2eb1edf184de3e75886464a06e26e972be8b264e4
-
-numpy==2.4.4+ppc64le1 \
-    --hash=sha256:3c0ede74d01bd0d1a55644b5b81f0b5cfc42355bebd8f93efcd837f0407781b3
 
 pandas==2.3.3+ppc64le1 \
     --hash=sha256:e2ece34c1d05e094e4ec6ce1aac552579c515a8a589669e235293b18f1624c6c
@@ -24,9 +18,6 @@ psutil==7.2.2+ppc64le1 \
 markupsafe==3.0.3+ppc64le1 \
     --hash=sha256:9e19dec5a2a3e1b44f9153edb60858d61f42f3b296e0f670b5dce7b8c8294f9b
 
-httptools==0.7.1+ppc64le1 \
-    --hash=sha256:483b99ef714ef4cf3fd43c86c95b81878f204de13bf088065cc1b5a42742adb2
-
 uvloop==0.22.1+ppc64le1 \
     --hash=sha256:a2ba692239f29c47352f3d1dd8c962c66da04c07b8641a05a8aeaf3decff0b7b
 
@@ -35,12 +26,3 @@ google-crc32c==1.8.0+ppc64le1 \
 
 ujson==5.11.0+ppc64le1 \
     --hash=sha256:941827306e7d611df191a753d58227c7b5550313da15a942356c3ab8915485ae
-
-grpcio==1.62.3+ppc64le1 \
-    --hash=sha256:20c871d8b8a47ee657902237cc5aaeec150823a70243824d6c0c52cf6d96ceb4
-
-#snowflake-connector-python==4.3.0+ppc64le1 \
-#    --hash=sha256:da61ba5d15b8c14858ba6ed5967bcf4d22c53451fcef8a86b6b4441c6af96e6c
-
-librt==0.8.1+ppc64le1 \
-    --hash=sha256:48036383ae90faed2fbd417180ef63c986f1b723b31f0d224ad9617d0883d761

--- a/sdk/python/feast/infra/feature_servers/multicloud/requirements-ppc64le2.txt
+++ b/sdk/python/feast/infra/feature_servers/multicloud/requirements-ppc64le2.txt
@@ -1,1 +1,19 @@
-snowflake-connector-python @ https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5-EA1/cpu-ubi9-test/snowflake_connector_python-4.4.0-2-cp312-cp312-linux_ppc64le.whl --hash=sha256:59b6031b547f02e84f6e6032948c1f8b7be49fd430d3c21488d87a3170343af8
+--index-url https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple/
+
+duckdb==1.5.3 \
+    --hash=sha256:1bf9c5699d62b4aef1f9635250762a68f8ed51e7d69c2f94800c2f2b9ae0f10e
+
+numpy==2.4.6 \
+    --hash=sha256:f07cd840335cc21424fdb1c31a6c1ff7acc27ea0d831c8b8ed30d83d952e9d89
+
+httptools==0.8.0 \
+    --hash=sha256:0d87c67fcf648e1b77acdd1eb0178be0a1252e3aeeec5985a9a7a87ae63dc05f
+
+grpcio==1.81.0 \
+    --hash=sha256:29a9464f0b2f53252958cc929c95641ea79ac4a0364a10d70ec20c0f86b85a26
+
+snowflake-connector-python==4.6.0 \
+    --hash=sha256:eeceee2769be282b2c5d50ca780dcf512dbdc50833071268c1050d7c7db79a26
+
+librt==0.11.0 \
+    --hash=sha256:675b97d0f0ba894e693ec8b6641b7790961725a4ad012e4937baa024fe3d6eb2


### PR DESCRIPTION
This PR updates the ppc64le-specific deps used by the feature-server image.

### Changes

* Update `requirements-ppc64le.txt`
* Update `requirements-ppc64le2.txt`
* Add a Power-specific installation step in `Dockerfile.feature-server.konflux` to install a validated `pyarrow` version during ppc64le builds
* Install `openblas-devel` to address NumPy runtime issues on ppc64le

### Motivation

The current dependency set can lead to build and runtime issues on ppc64le. This change updates the Power-specific dependency configuration, ensures a compatible `pyarrow` version is used during feature-server image builds, and adds `openblas-devel` to resolve NumPy runtime failures caused by missing OpenBLAS libraries.

### Testing

* Verified feature-server image build on ppc64le
* Confirmed successful installation of dependencies during the build
* Verified NumPy imports successfully at runtime
* Verified non-Power architectures are unaffected
